### PR TITLE
Make the web build cheap enough to run at speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ bin/test                        # the whole suite
 bin/test tests/framing_tests.rb # one file
 ```
 
-619 tests across 50 files, run headless in DragonRuby's own test runner.
+827 tests across 57 files, run headless in DragonRuby's own test runner.
 `bin/test` wraps it because `--test` always exits 0, which is no use to anyone
 who wants to know whether the tests passed.
 

--- a/app/main.rb
+++ b/app/main.rb
@@ -307,6 +307,12 @@ class Game
     state.direction = :right
     state.world_cache = {}
     state.beach_band = nil # measured off stamped segments; it cannot outlive them
+    # The far ranges are read off the islands, so they cannot outlive them
+    # either — and they did: a new round opened with the previous round's hills
+    # standing behind this round's coast. Both the silhouettes and the crown
+    # heights kept off them go here.
+    state.backdrop_isles = {}
+    state.backdrop_lifts = {}
     # Forget which world is loaded, too: the cache alone isn't enough, and the
     # round would otherwise start out on the *previous* round's segment — old
     # island layout, old fish — until the diver happened to cross a border.

--- a/app/world/backdrop.rb
+++ b/app/world/backdrop.rb
@@ -109,7 +109,9 @@ class Game
   end
 
   # The island as an object, so its crown can be asked about. Memoised: building
-  # one rolls its whole shape, and this runs every frame.
+  # one rolls its whole shape, and this runs every frame. Game#reset_game drops
+  # the lot — a new round is new land, and a silhouette that outlives the island
+  # it came off draws the previous round's hills behind this one's coast.
   def backdrop_island(sector)
     state.backdrop_isles ||= {}
     state.backdrop_isles[sector] ||= IslandWorld.new(world_at(sector), sector)
@@ -157,10 +159,35 @@ class Game
     centre + (world_x - centre - shift) / wider
   end
 
-  # How high this column stands over the water. Zero wherever the island's own
-  # crown is at or below the waterline, which is what keeps the range inside the
-  # land it belongs to and lets it end without a cut.
+  # How high this column stands over the water — worked out once per place and
+  # kept.
+  #
+  # Keeping it is the whole payoff of walking a fixed world grid. Every sample
+  # rolls a crown height and three octaves of canopy noise, and Noise.jitter
+  # builds an Rng to do each of them; at ~150 samples a rank, two ranks and up
+  # to three islands in view, the far hills came to 5.5 ms of a 9 ms frame —
+  # more than the sea floor, the fish and the HUD together, spent re-rolling
+  # hills that had not moved. Since the answer cannot depend on anything but the
+  # place (that is what tests/vegetation_tests.rb#test_the_canopy_holds_still is
+  # for), asking twice is pure waste.
+  #
+  # It is bounded by the land rather than by how far anyone swims: a range only
+  # reaches so far past its island (visible_islands), so an island's whole ridge
+  # is about a thousand numbers and a round holds four islands. It goes when
+  # they do (reset_game).
   def backdrop_lift(isle, source_x, taller, index)
+    lifts = (state.backdrop_lifts ||= {})
+    key = "#{isle.sector} #{index} #{source_x}"
+    kept = lifts[key]
+    return kept if kept
+
+    lifts[key] = rolled_backdrop_lift(isle, source_x, taller, index)
+  end
+
+  # Zero wherever the island's own crown is at or below the waterline, which is
+  # what keeps the range inside the land it belongs to and lets it end without
+  # a cut.
+  def rolled_backdrop_lift(isle, source_x, taller, index)
     above = isle.crown_y_at(source_x) - WATERLINE_Y
     return 0 if above <= 0
 

--- a/app/world/fog_of_war.rb
+++ b/app/world/fog_of_war.rb
@@ -1,4 +1,21 @@
+# The dark closing in around the diver: everything further off than the radius
+# is painted over, on a 40 px grid so the edge is blocky rather than smooth.
+#
+# It used to be emitted one cell at a time — 33 × 19 of them, each with its own
+# square root and its own hash, of which up to 582 were actually drawn. That is
+# most of a frame's primitives spent on a shape with two edges, and it was the
+# single largest thing the web build was paying for.
+#
+# A row of the grid is a *run*: the clear circle cuts one contiguous hole out of
+# it, so everything left of the hole is one rect and everything right of it is
+# another. Same grid, same blocky edge, the same cells dark — 26 rects instead
+# of 582, and one square root per row instead of one per cell.
+# tests/fog_of_war_tests.rb holds the runs against a cell-by-cell reading.
 class FogOfWar
+  CELL = 40
+  LAST_COL = 32 # x: 0..32 ...
+  LAST_ROW = 18 # ... y: 0..18 — a little past the screen on both axes
+
   # radius: how far the diver can see (bigger = brighter, more open water).
   # color:  the fog tint, so it blends with the biome's deep water.
   def initialize(diver, radius: 220, color: [8, 5, 77])
@@ -21,12 +38,52 @@ class FogOfWar
   end
 
   def to_a
-    (0..32).map do |x|
-      (0..18).map do |y|
-        if Math.sqrt((@diver.to_h[:x] - x * 40)**2 + (@diver.to_h[:y] - y * 40)**2) > @radius
-          fog_square(40 * x, 40 * y, 40, 40)
-        end
-      end
-    end.flatten.compact
+    here = @diver.to_h
+    dark = []
+    row = 0
+    while row <= LAST_ROW
+      add_row(dark, here[:x], here[:y], row)
+      row += 1
+    end
+    dark
+  end
+
+  private
+
+  # One row of the grid: the dark either side of the clear span, or the whole
+  # row where the circle does not reach it at all.
+  def add_row(dark, x, y, row)
+    clear = clear_span(x, y, row)
+    unless clear
+      dark << fog_square(0, row * CELL, (LAST_COL + 1) * CELL, CELL)
+      return
+    end
+
+    first, last = clear
+    dark << fog_square(0, row * CELL, first * CELL, CELL) if first > 0
+    return unless last < LAST_COL
+
+    dark << fog_square((last + 1) * CELL, row * CELL, (LAST_COL - last) * CELL, CELL)
+  end
+
+  # The columns of this row the diver can see, as [first, last] — or nil if the
+  # circle misses the row entirely and the whole of it is dark.
+  #
+  # A cell is clear when it is no further off than the radius, which for a fixed
+  # row is |x - col * CELL| <= sqrt(radius² - dy²): one square root for the row,
+  # and the ends of the span fall out of it by rounding inward.
+  def clear_span(x, y, row)
+    dy = y - row * CELL
+    reach = @radius * @radius - dy * dy
+    return nil if reach < 0
+
+    half = Math.sqrt(reach)
+    first = ((x - half) / CELL.to_f).ceil
+    last = ((x + half) / CELL.to_f).floor
+    first = 0 if first < 0
+    last = LAST_COL if last > LAST_COL
+    return nil if last < first
+
+    [first, last]
   end
 end

--- a/app/world/world_renderer.rb
+++ b/app/world/world_renderer.rb
@@ -90,6 +90,36 @@ class Game
     (bare * sight_factor).to_i # ... and a better mask sees through more of it
   end
 
+  # The slice of screen the fog leaves open, as [left, right] — or nil where
+  # there is no fog and the whole screen is on show.
+  #
+  # The fog is opaque and it is a circle, so terrain outside it is built, drawn,
+  # and then painted straight over. Across the sea that is about seven rects in
+  # ten. Everything that draws the sea draws the fog with it (render_fog), so
+  # the same three conditions decide both — which is what keeps this from
+  # cutting a hole in a picture that has nothing over it: the surface, the
+  # framing screens where the diver floats at the boat, and the boat itself.
+  #
+  # A cell of slack either side, because the fog is snapped out to its own grid
+  # and the clear circle can reach that much further than the radius says.
+  def fog_window
+    return nil unless FOG_OF_WAR
+    return nil if at_open_surface?
+    return nil if state.aboard
+
+    reach = fog_radius(current_world.biome) + FogOfWar::CELL
+    [state.player_x - reach, state.player_x + reach]
+  end
+
+  # Is this run of columns entirely outside that slice, and so entirely behind
+  # the fog? Always false where there is no window, which is how the surface and
+  # the framing screens keep the whole picture.
+  def behind_the_fog?(window, x, w)
+    return false unless window
+
+    x + w < window[0] || x > window[1]
+  end
+
   # Tint the fog with the biome's deep water so it blends instead of a flat blue,
   # and let it darken with depth along with the water itself.
   def fog_color(biome)
@@ -114,11 +144,12 @@ class Game
     # side, which is exactly what watching a boat pass behind a headland looks
     # like.
     render_home_boat
+    window = fog_window
     visible_world_indices.each do |index|
       world = world_at(index)
       dx = chunk_offset_x(index)
-      outputs.sprites << world_floor(world, dx) if submerged_visible?
-      outputs.sprites << world_roof(world, dx)
+      outputs.sprites << world_floor(world, dx, window) if submerged_visible?
+      outputs.sprites << world_roof(world, dx, window)
       outputs.sprites << world_air(world, dx) if submerged_visible?
       outputs.sprites << world_decorations(world, dx)
     end
@@ -289,7 +320,7 @@ class Game
   # as chunky pixel steps. Tinting follows the height (like strata) rather than
   # the column, which keeps a terrace one flat colour, and everything darkens
   # with depth.
-  def world_floor(world, dx)
+  def world_floor(world, dx, window = nil)
     body = world.biome.floor_colors[1].map { |c| c - 14 }
     cap = world.biome.floor_colors[0]
     tiles = []
@@ -299,6 +330,8 @@ class Game
 
       x = first_col * World::COLUMN_WIDTH + dx
       w = width * World::COLUMN_WIDTH + 1
+      next if behind_the_fog?(window, x, w)
+
       shade = (top.idiv(WorldGenerator::FLOOR_STEP) % 5 - 2) * 4 # strata, not stripes
       dim = light_at(top)
       tiles << sand({ x: x, y: y - FLOOR_FILL_DEPTH, w: w, h: FLOOR_FILL_DEPTH }, body, shade, dim)
@@ -343,12 +376,14 @@ class Game
   # the top of *that*: an island's flank above the water is in daylight while the
   # same slab is pitch dark down at the tunnel. A slab that breaks the surface
   # gets earth colours and a band of green along its crown.
-  def world_roof(world, dx)
+  def world_roof(world, dx, window = nil)
     return [] unless world.roof
 
     tiles = []
     each_run(world.roof) do |slabs, first_col, width|
       next if slabs.nil? || slabs.empty?
+      next if behind_the_fog?(window, first_col * World::COLUMN_WIDTH + dx,
+                              width * World::COLUMN_WIDTH + 1)
 
       slabs.each { |rock| roof_slab(tiles, world, rock, first_col, width, dx) }
     end

--- a/tests/all_tests.rb
+++ b/tests/all_tests.rb
@@ -55,4 +55,4 @@ require "tests/shot_card_tests.rb"
 require "tests/assignment_tests.rb"
 require "tests/reef_tests.rb"
 require "tests/wreck_tests.rb"
-
+require "tests/render_budget_tests.rb"

--- a/tests/fog_of_war_tests.rb
+++ b/tests/fog_of_war_tests.rb
@@ -11,29 +11,117 @@ class FogOfWarTests
     end
   end
 
+  CELL = FogOfWar::CELL
   TOTAL_CELLS = 33 * 19 # x: 0..32, y: 0..18
 
-  def test_everything_is_fogged_when_diver_is_far_away(args, assert)
-    fog = FogOfWar.new(DiverStub.new(-10_000, -10_000)).to_a
+  # What the fog *means*, spelled out the plain way: one 40 px cell at a time,
+  # dark wherever the diver is further off than the radius. The fog is drawn as
+  # row runs now — two rects a row instead of up to thirty-three — so this is
+  # what the runs are held against. If the two ever disagree the shape changed,
+  # which is the only thing about the fog that was ever meant to be fixed.
+  def reference_cells(x, y, radius)
+    cells = {}
+    (0..32).each do |cx|
+      (0..18).each do |cy|
+        next unless Math.sqrt((x - cx * CELL)**2 + (y - cy * CELL)**2) > radius
 
-    assert.equal! fog.length, TOTAL_CELLS
+        cells["#{cx},#{cy}"] = true
+      end
+    end
+    cells
+  end
+
+  # The cells a list of fog rects actually covers.
+  def covered_cells(rects)
+    cells = {}
+    rects.each do |rect|
+      cx = rect[:x].idiv(CELL)
+      last_x = (rect[:x] + rect[:w]).idiv(CELL)
+      while cx < last_x
+        cy = rect[:y].idiv(CELL)
+        last_y = (rect[:y] + rect[:h]).idiv(CELL)
+        while cy < last_y
+          cells["#{cx},#{cy}"] = true
+          cy += 1
+        end
+        cx += 1
+      end
+    end
+    cells
+  end
+
+  def fog_at(x, y, radius)
+    FogOfWar.new(DiverStub.new(x, y), radius: radius).to_a
+  end
+
+  def test_everything_is_fogged_when_diver_is_far_away(args, assert)
+    fog = fog_at(-10_000, -10_000, 220)
+
+    assert.equal! covered_cells(fog).length, TOTAL_CELLS
   end
 
   def test_area_around_diver_is_clear(args, assert)
     # With the diver on-screen, the cells within radius 220 are not fogged,
     # so fewer than all cells come back.
-    fog = FogOfWar.new(DiverStub.new(640, 360)).to_a
+    cells = covered_cells(fog_at(640, 360, 220))
 
-    assert.true! fog.length > 0,             "expected some fog, got none"
-    assert.true! fog.length < TOTAL_CELLS,   "expected a clear area, got full fog"
+    assert.true! cells.length > 0,           "expected some fog, got none"
+    assert.true! cells.length < TOTAL_CELLS, "expected a clear area, got full fog"
   end
 
-  def test_fog_squares_are_40x40_solids(args, assert)
-    fog = FogOfWar.new(DiverStub.new(-10_000, -10_000)).to_a
-    square = fog.first
+  def test_fog_squares_are_a_row_of_the_grid_tall(args, assert)
+    square = fog_at(-10_000, -10_000, 220).first
 
-    assert.equal! square[:w], 40
-    assert.equal! square[:h], 40
+    assert.equal! square[:h], CELL
     assert.equal! square[:path], :solid
+    assert.equal! square[:w] % CELL, 0, "a run is a whole number of cells wide"
+  end
+
+  # The whole point of the runs: the same picture, a fraction of the rects. It
+  # used to push up to 582 of them a frame — most of everything the sea drew.
+  MOST_RECTS = 40
+
+  def test_the_fog_is_drawn_as_runs_not_as_cells(args, assert)
+    # The tightest fog there is (the deep, at depth) is also the fog that used
+    # to cost the most, because the smaller the clear circle the more cells fall
+    # outside it.
+    [120, 153, 220, 293, 410].each do |radius|
+      fog = fog_at(640, 360, radius)
+
+      assert.true! fog.length <= MOST_RECTS,
+                   "radius #{radius} came out in #{fog.length} rects, not #{MOST_RECTS} or fewer"
+    end
+  end
+
+  # And the same picture: run-merged or cell by cell, the dark has to fall on
+  # exactly the same 40 px squares. Walked across radii and positions, including
+  # the corners and well off the screen, where the circle only clips a row or two.
+  def test_the_runs_cover_exactly_what_the_cells_did(args, assert)
+    checked = 0
+    [80, 120, 153, 220, 240, 293, 350, 410].each do |radius|
+      [[640, 360], [0, 0], [1279, 719], [200, 120], [1100, 640],
+       [640, 60], [-300, 360], [1600, 360], [640, -200], [640, 900]].each do |(x, y)|
+        assert.equal! covered_cells(fog_at(x, y, radius)), reference_cells(x, y, radius),
+                      "fog at #{x},#{y} radius #{radius} covers different cells"
+        checked += 1
+      end
+    end
+
+    assert.true! checked >= 80, "only #{checked} combinations checked"
+  end
+
+  # The diver does not stand on the grid, so the awkward cases are the ones
+  # where he is a pixel or two off it. Rolled rather than listed: a fixed
+  # handful of positions is exactly the handful an off-by-one hides between.
+  def test_the_runs_hold_at_positions_off_the_grid(args, assert)
+    rng = Rng.new(20_260_802)
+    120.times do
+      x = rng.int(1400) - 60
+      y = rng.int(800) - 40
+      radius = 60 + rng.int(360)
+
+      assert.equal! covered_cells(fog_at(x, y, radius)), reference_cells(x, y, radius),
+                    "fog at #{x},#{y} radius #{radius} covers different cells"
+    end
   end
 end

--- a/tests/pause_tests.rb
+++ b/tests/pause_tests.rb
@@ -1,9 +1,19 @@
 # The pause menu: ESC freezes the dive with a choice instead of throwing the
 # round away, and you can carry on or end the dive.
 class PauseTests
-  # Fog squares are a 40x40 grid of solids; nothing else in the scene is.
-  def fog_squares(args)
-    args.outputs.sprites.flatten.count { |s| s[:w] == 40 && s[:h] == 40 && s[:path] == :solid }
+  # How much of the screen the dark covers. The fog is drawn on a 40 px grid, a
+  # row at a time, so it is the solids that are exactly one cell tall and a whole
+  # number of cells wide — and it is the *area* that matters here, not the count:
+  # the runs cover the same screen in far fewer rects than the old cell-by-cell
+  # fog did, and counting rects would read that as the dark having lifted.
+  def fogged_area(args)
+    cell = FogOfWar::CELL
+    args.outputs.sprites.flatten.reduce(0) do |area, s|
+      next area unless s[:path] == :solid && s[:h] == cell
+      next area unless s[:w] % cell == 0 && s[:x] % cell == 0 && s[:y] % cell == 0
+
+      area + s[:w] * s[:h]
+    end
   end
 
   # Pausing showed the whole map. The dark is part of the world, but it was being
@@ -19,7 +29,7 @@ class PauseTests
 
     game.area1_tick
     game.render_diver
-    diving = fog_squares(args)
+    diving = fogged_area(args)
     assert.true! diving > 0, "there is fog down here to begin with (#{diving})"
 
     args.outputs.sprites.clear
@@ -27,8 +37,8 @@ class PauseTests
     args.state.paused_at = Kernel.tick_count # so the menu doesn't read its own key
     game.pause_tick
 
-    assert.true! fog_squares(args) >= diving,
-                 "and it is still there behind the menu (#{fog_squares(args)} of #{diving})"
+    assert.true! fogged_area(args) >= diving,
+                 "and it is still there behind the menu (#{fogged_area(args)} of #{diving})"
   end
 
   def build_game(args)

--- a/tests/render_budget_tests.rb
+++ b/tests/render_budget_tests.rb
@@ -1,0 +1,205 @@
+# What a frame is allowed to cost.
+#
+# The game runs in a browser as well as on a desktop, and the browser is where
+# it showed: mruby is a good deal slower under WASM and every primitive has to
+# cross into the engine, so a frame that a Mac shrugs off is a frame the web
+# build stutters on. Three things were paying for that and none of them had to:
+#
+#   * the far ridge was re-rolling hills that had not moved (app/world/backdrop.rb)
+#   * the fog was drawn one 40 px cell at a time (app/world/fog_of_war.rb)
+#   * the sea floor was drawn out to the screen edge, under opaque fog
+#
+# These are the guards on all three. They are budgets rather than exact numbers:
+# the point is that nobody quietly puts a thousand rects back.
+class RenderBudgetTests
+  def build_game(args)
+    game = Game.new
+    game.args = args
+    game.initialize_game(0)
+    args.state.game_scene = "area1"
+    game
+  end
+
+  # Stand the diver in the open water of a segment, a little above its floor.
+  def dive_at(game, args, sector)
+    x = sector * SCREEN_WIDTH + 640
+    args.state.diver_global_x = x
+    args.state.depth_y = WorldGenerator.floor_y_at(x) + 320
+    game.center_camera
+    game.current_world
+  end
+
+  # Float him at a given x and say whether his head actually came out. It may
+  # not have: an island reaches a long way out under water, and a spot that
+  # looks like open sea beside one is often the roof of its flank, which holds
+  # him under (clamp_depth).
+  def surface_at(game, args, x)
+    args.state.diver_global_x = x
+    args.state.depth_y = WATERLINE_Y
+    game.center_camera
+    game.current_world
+    game.at_open_surface?
+  end
+
+  # Open water within sight of an island: near enough that its far range is in
+  # the picture, clear enough of it that he is floating rather than under rock.
+  def surface_beside(game, args, sector)
+    centre = IslandWorld.centre_x(sector)
+    [900, 1400, 1900, 2400, -900, -1400, -1900, -2400].each do |offset|
+      return centre + offset if surface_at(game, args, centre + offset)
+    end
+    nil
+  end
+
+  def primitives(args)
+    args.outputs.sprites.flatten.compact.length
+  end
+
+  def one_tick(game, args)
+    args.outputs.sprites.clear
+    args.outputs.labels.clear
+    game.tick
+    primitives(args)
+  end
+
+  # --- the frame budget ------------------------------------------------------
+
+  # Measured across the sea it was 500–1344 primitives a frame, of which the fog
+  # alone was up to 582 and the sea floor mostly hidden behind it. This is the
+  # ceiling that keeps that from coming back; a comfortable frame is well under.
+  FRAME_BUDGET = 800
+
+  def test_a_dive_stays_inside_the_frame_budget(args, assert)
+    game = build_game(args)
+    worst = 0
+    worst_at = nil
+
+    (-6..12).each do |sector|
+      dive_at(game, args, sector)
+      count = one_tick(game, args)
+      if count > worst
+        worst = count
+        worst_at = sector
+      end
+    end
+
+    assert.true! worst <= FRAME_BUDGET,
+                 "sector #{worst_at} draws #{worst} primitives, over the #{FRAME_BUDGET} budget"
+  end
+
+  # The surface next to an island is the other busy place: no fog to hide the
+  # terrain, and the far range drawn on top. It gets a looser budget because it
+  # genuinely has more to show, but not an open one.
+  SURFACE_BUDGET = 1200
+
+  def test_the_surface_beside_an_island_stays_inside_its_budget(args, assert)
+    game = build_game(args)
+    worst = 0
+    worst_at = nil
+
+    args.state.island_sectors.each do |sector|
+      next unless surface_beside(game, args, sector)
+
+      assert.true! game.backdrop_visible?, "island #{sector} has its range in view"
+      count = one_tick(game, args)
+      if count > worst
+        worst = count
+        worst_at = sector
+      end
+    end
+
+    assert.true! worst > 0, "no island had open water beside it to float in"
+    assert.true! worst <= SURFACE_BUDGET,
+                 "island #{worst_at} draws #{worst} primitives, over the #{SURFACE_BUDGET} budget"
+  end
+
+  # --- the terrain clip ------------------------------------------------------
+
+  # Under water the fog is opaque, so terrain outside its circle is drawn and
+  # then painted over. It is left out instead — but only what the fog would
+  # have covered, which is what this holds it to: everything the player could
+  # actually see is still built.
+  def test_the_clip_drops_nothing_the_diver_could_see(args, assert)
+    game = build_game(args)
+
+    (-6..12).each do |sector|
+      dive_at(game, args, sector)
+      window = game.fog_window
+      assert.true! !window.nil?, "sector #{sector} is under water, so there is a fog window"
+
+      game.visible_world_indices.each do |index|
+        world = game.world_at(index)
+        dx = game.chunk_offset_x(index)
+        drawn = (game.world_floor(world, dx, window) +
+                 game.world_roof(world, dx, window)).flatten.compact
+        every = (game.world_floor(world, dx) + game.world_roof(world, dx)).flatten.compact
+
+        missing = every.reject do |rect|
+          rect[:x] + rect[:w] < window[0] || rect[:x] > window[1] ||
+            drawn.any? { |kept| kept[:x] == rect[:x] && kept[:y] == rect[:y] && kept[:w] == rect[:w] }
+        end
+        assert.equal! missing.length, 0,
+                      "sector #{sector} dropped #{missing.length} rects inside the fog window"
+      end
+    end
+  end
+
+  def test_the_clip_actually_leaves_something_out(args, assert)
+    game = build_game(args)
+    clipped = 0
+    every = 0
+
+    (-6..12).each do |sector|
+      dive_at(game, args, sector)
+      window = game.fog_window
+      game.visible_world_indices.each do |index|
+        world = game.world_at(index)
+        dx = game.chunk_offset_x(index)
+        clipped += (game.world_floor(world, dx, window) +
+                    game.world_roof(world, dx, window)).flatten.compact.length
+        every += (game.world_floor(world, dx) + game.world_roof(world, dx)).flatten.compact.length
+      end
+    end
+
+    assert.true! clipped < every / 2,
+                 "the clip only saved #{every - clipped} of #{every} rects — it is not biting"
+  end
+
+  # There is nothing to hide behind at the surface, so nothing may be left out
+  # there. The framing screens (the title, the recap, the boat menus) park the
+  # camera at the boat with the diver floating, and they go through the same
+  # gate — a clipped horizon would be a hole in the picture.
+  def test_nothing_is_clipped_where_there_is_no_fog(args, assert)
+    game = build_game(args)
+    found = surface_beside(game, args, args.state.island_sectors.first)
+    assert.true! !found.nil?, "found open water beside the island to float in"
+
+    assert.true! game.at_open_surface?, "the diver is up in the air"
+    assert.true! game.fog_window.nil?, "no fog up here, so no window to clip to"
+
+    # Which is to say render_world asks for a window, gets nil, and draws the lot
+    # — the same list it builds when nobody clips at all.
+    game.visible_world_indices.each do |index|
+      world = game.world_at(index)
+      dx = game.chunk_offset_x(index)
+      assert.equal! game.world_floor(world, dx, game.fog_window).flatten.compact.length,
+                    game.world_floor(world, dx).flatten.compact.length,
+                    "the floor was clipped at the surface"
+      assert.equal! game.world_roof(world, dx, game.fog_window).flatten.compact.length,
+                    game.world_roof(world, dx).flatten.compact.length,
+                    "the rock was clipped at the surface"
+    end
+  end
+
+  # Aboard, the diver is not drawn and neither is his fog, whatever the depth
+  # says. Clipping to a circle that is not there would cut the sea in half.
+  def test_nothing_is_clipped_from_the_boat(args, assert)
+    game = build_game(args)
+    dive_at(game, args, 0)
+    assert.true! !game.fog_window.nil?, "in the water there is a window"
+
+    args.state.aboard = true
+
+    assert.true! game.fog_window.nil?, "aboard there is no fog, so nothing to clip to"
+  end
+end

--- a/tests/vegetation_tests.rb
+++ b/tests/vegetation_tests.rb
@@ -158,4 +158,56 @@ class VegetationTests
 
     assert.equal! second, first, "the same place has to keep the same crown"
   end
+
+  # --- and how it is kept ----------------------------------------------------
+  #
+  # Because it holds still, it is worked out once per place and remembered
+  # (Game#backdrop_lift). That is worth its own guard in both directions: a
+  # cache that answers too readily draws one island's hills behind another, and
+  # a cache that outlives its islands draws last round's.
+
+  def test_the_kept_crowns_are_told_apart(args, assert)
+    game = backdrop_game(args)
+    sector = args.state.island_sectors.first
+    isle = game.backdrop_island(sector)
+    centre = IslandWorld.centre_x(sector)
+
+    assert.equal! game.backdrop_lift(isle, centre, 2.3, 0),
+                  game.backdrop_lift(isle, centre, 2.3, 0),
+                  "asking twice has to give the same answer"
+
+    # Two neighbouring places may honestly share a height, and so may the two
+    # ranks at one place — both round to BACKDROP_STEP. What cannot happen is a
+    # whole ridge coming back as another ridge, so they are compared as lines.
+    near = tree_line(game, sector, 60)
+    far = []
+    (0...60).each do |i|
+      lift = game.backdrop_lift(isle, centre + (i - 30) * Game::BACKDROP_SAMPLE, 1.75, 1)
+      far << lift if lift > 0
+    end
+
+    assert.true! near.length > 20, "the near rank is actually there"
+    assert.true! far.length > 20, "the far rank is actually there"
+    assert.true! near != far, "the two ranks came back as one ridge"
+  end
+
+  # A new career rolls a new seed, so the islands are new land: different
+  # sectors, different shapes. Everything read off them has to go with them —
+  # the silhouettes themselves and the crowns kept off them alike. The far hills
+  # used to survive a reset (state.backdrop_isles was never cleared), so a new
+  # round opened with the previous round's range standing behind its islands.
+  def test_a_new_round_forgets_the_old_islands(args, assert)
+    game = backdrop_game(args)
+    sector = args.state.island_sectors.first
+    before = game.backdrop_island(sector)
+    game.backdrop_lift(before, IslandWorld.centre_x(sector), 2.3, 0)
+
+    args.state.world_seed = args.state.world_seed + 1
+    game.reset_game
+
+    after = game.backdrop_island(sector)
+
+    assert.true! !after.equal?(before),
+                 "the range behind an island outlived the island it came off"
+  end
 end


### PR DESCRIPTION
## Motivation

The browser build had got slow. Profiling a tick headless (DragonRuby's own
test runner, 38 spots across the sea) showed the desktop build was already
close to its budget — worst frame **15.1 ms** and **1344 primitives** — and the
web build has neither the headroom nor the draw-call budget for that: mruby is
markedly slower under WASM and every primitive has to cross into the engine.

Three things were paying for it, none of which had to.

## What's inside

**The far ridge was re-rolling hills that had not moved.** `backdrop_lift` walks
~150 samples a rank, two ranks, up to three islands, and each sample rolls a
crown height plus three octaves of canopy noise — every one of them building an
`Rng`. It already walks a fixed world grid so the same place answers the same,
so it is now worked out once and kept. **5.5 ms → 0.14 ms.** Bounded by the land
rather than by how far anyone swims (~1000 numbers per island, four a round).

**The fog was drawn one 40 px cell at a time** — 33 × 19 of them, up to 582
actually drawn, 44–70 % of everything on screen. The clear circle cuts one
contiguous hole out of a row, so a row is at most two rects. **582 → 26 rects,
one square root per row instead of one per cell.**

**Terrain outside the fog was drawn and then painted over** — about seven rects
in ten. `world_floor` / `world_roof` now skip column runs outside the slice the
fog leaves open. The window is nil where there is no fog to hide behind (the
surface, the framing screens, aboard), and then everything is drawn as before.

Measured over the same 38 spots, native:

| | primitives (worst) | frame (worst) | frame (mean) |
|---|---|---|---|
| before | 1344 | 15.1 ms | 5.2 ms |
| after | 662 | 2.2 ms | 0.9 ms |

**Bug found alongside:** `state.backdrop_isles` was never cleared, so the far
silhouettes outlived the islands they were read off — a new round opened with
the previous round's hills standing behind this round's coast. `reset_game`
drops them now.

Nothing here is meant to change the picture, and the tests are written to hold
that: the fog runs are checked against a cell-by-cell reading of the radius over
200 positions on and off the grid, and the clip is checked rect by rect to drop
nothing inside the window. `tests/render_budget_tests.rb` adds a ceiling on
primitives per frame so nobody quietly puts a thousand rects back.

827 tests, green. (`ShotCardTests#test_the_shot_result_is_no_longer_a_message_row`
is intermittently inconclusive — it asserts inside a loop that is sometimes
empty. Pre-existing, reproduces on `main`.)

## Deployment hints

Nothing to migrate, no save-file or asset change — it is renderer-side only.

- `bin/test` before building, as usual.
- Needs a look in the running game before merging: the maths says the picture is
  identical, but I have only proved that headless. Worth swimming past an island
  at the surface (the ridge), sitting in the deep (the fog edge) and pausing
  under water (the fog behind the menu).
- Then the usual HTML5 route in `DEPLOY.md` — the version bump in `metadata/` is
  local, since that folder is gitignored.
